### PR TITLE
Enumerate Songs and Instruments

### DIFF
--- a/include/sound/sample_brr.inc
+++ b/include/sound/sample_brr.inc
@@ -4,6 +4,45 @@ SAMPLE_BRR_INC = 1
 
 .global SampleBRR, SampleBRRPtrs
 
+; instrument sample ids
+.enum SAMPLE_BRR
+    BASS_DRUM       ; $01
+    SNARE           ; $02
+    HARD_SNARE      ; $03
+    CYMBAL          ; $04
+    TOM             ; $05
+    CLOSED_HIHAT    ; $06
+    OPEN_HIHAT      ; $07
+    TIMPANI         ; $08
+    VIBRAPHONE      ; $09
+    MARIMBA         ; $0a
+    STRINGS         ; $0b
+    CHOIR           ; $0c
+    HARP            ; $0d
+    TRUMPET         ; $0e
+    OBOE            ; $0f
+    FLUTE           ; $10
+    ORGAN           ; $11
+    PIANO           ; $12
+    ELECTRIC_BASS   ; $13
+    BASS_GUITAR     ; $14
+    GRAND_PIANO     ; $15
+    MUSIC_BOX_INSTR ; $16
+    WOO             ; $17
+    METAL_SYSTEM    ; $18
+    SYNTH_CHORD     ; $19
+    DIST_GUITAR     ; $1a
+    KRABI           ; $1b
+    HORN            ; $1c
+    MANDOLIN        ; $1d
+    UNKNOWN_1       ; $1e
+    CONGA           ; $1f
+    CASABA          ; $20
+    KLAVES          ; $21
+    UNKNOWN_2       ; $22
+    HAND_CLAP       ; $23
+.endenum
+
 .scope SampleBRR
 
 ; ##############################################################################

--- a/include/sound/song_script.inc
+++ b/include/sound/song_script.inc
@@ -4,6 +4,82 @@ SONG_SCRIPT_INC = 1
 
 .global SongScript, SongScriptPtrs
 
+; song ids
+.enum SONG
+        AHEAD_ON_OUR_WAY                ; $00
+        THE_FIERCE_BATTLE               ; $01
+        A_PRESENTIMENT                  ; $02
+        GO_GO_BOKO                      ; $03
+        PIRATES_AHOY                    ; $04
+        TENDERNESS_IN_THE_AIR           ; $05
+        FATE_IN_HAZE                    ; $06
+        CRITTER_TRIPPER_FRITTER         ; $07
+        THE_PRELUDE                     ; $08
+        THE_LAST_BATTLE                 ; $09
+        REQUIEM                         ; $0a
+        NOSTALGIA                       ; $0b
+        CURSED_EARTHS                   ; $0c
+        LENNAS_THEME                    ; $0d
+        VICTORYS_FANFARE                ; $0e
+        DECEPTION                       ; $0f
+        THE_DAY_WILL_COME               ; $10
+        SILENCE                         ; $11
+        EXDEATHS_CASTLE                 ; $12
+        MY_HOME_SWEET_HOME              ; $13
+        WALTZ_SUOMI                     ; $14
+        SEALED_AWAY                     ; $15
+        THE_FOUR_WARRIORS_OF_DAWN       ; $16
+        DANGER                          ; $17
+        THE_FIREPOWERED_SHIP            ; $18
+        AS_I_FEEL_YOU_FEEL              ; $19
+        MAMBO_DE_CHOCOBO                ; $1a
+        MUSIC_BOX_SONG                  ; $1b
+        INTENSION_OF_THE_EARTH          ; $1c
+        THE_DRAGON_SPREADS_ITS_WINGS    ; $1d
+        BEYOND_THE_DEEP_BLUE_SEA        ; $1e
+        PRELUDE_OF_EMPTY_SKIES          ; $1f
+        SEARCHING_FOR_THE_LIGHT         ; $20
+        HARVEST                         ; $21
+        GILGAMESH                       ; $22
+        FOUR_VALIANT_HEARTS             ; $23
+        THE_BOOK_OF_SEALINGS            ; $24
+        WHAT                            ; $25
+        HURRY_HURRY                     ; $26
+        UNKNOWN_LANDS                   ; $27
+        THE_AIRSHIP                     ; $28
+        FANFARE_1                       ; $29
+        FANFARE_2                       ; $2a
+        THE_BATTLE                      ; $2b
+        WALKING_THE_SNOWY_MOUNTAINS     ; $2c
+        THE_EVIL_LORD_EXDEATH           ; $2d
+        THE_CASTLE_OF_DAWN              ; $2e
+        IM_A_DANCER                     ; $2f
+        REMINISCENCE                    ; $30
+        RUN                             ; $31
+        THE_ANCIENT_LIBRARY             ; $32
+        ROYAL_PALACE                    ; $33
+        GOOD_NIGHT                      ; $34
+        PIANO_LESSON_1                  ; $35
+        PIANO_LESSON_2                  ; $36
+        PIANO_LESSON_3                  ; $37
+        PIANO_LESSON_4                  ; $38
+        PIANO_LESSON_5                  ; $39
+        PIANO_LESSON_6                  ; $3a
+        PIANO_LESSON_7                  ; $3b
+        PIANO_LESSON_8                  ; $3c
+        MUSICA_MACHINA                  ; $3d
+        A_METEOR_IS_FALLING             ; $3e
+        THE_LAND_UNKNOWN                ; $3f
+        THE_DECISIVE_BATTLE             ; $40
+        THE_SILENT_BEYOND               ; $41
+        DEAR_FRIENDS                    ; $42
+        FINAL_FANTASY                   ; $43
+        A_NEW_ORIGIN                    ; $44
+        CRICKETS_CHIRPING               ; $45
+        A_SHORE                         ; $46
+        THE_TIDE_ROLLS_IN               ; $47
+.endenum
+
 .scope SongScript
 
 ; ##############################################################################

--- a/src/sound/song-data.asm
+++ b/src/sound/song-data.asm
@@ -21,121 +21,121 @@ SampleBRRPtrs:
 
 ; c4/3cd8
 SampleLoopStart:
-        .word   $0a8c
-        .word   $0bd9
-        .word   $1194
-        .word   $05fa
-        .word   $15f9
-        .word   $0465
-        .word   $1194
-        .word   $1194
-        .word   $04f5
-        .word   $029a
-        .word   $08f7
-        .word   $02c7
-        .word   $034e
-        .word   $04da
-        .word   $0252
-        .word   $0489
-        .word   $0936
-        .word   $0642
-        .word   $0144
-        .word   $044a
-        .word   $05bb
-        .word   $0666
-        .word   $1194
-        .word   $09bd
-        .word   $0384
-        .word   $05bb
-        .word   $092d
-        .word   $15f9
-        .word   $0318
-        .word   $077d
-        .word   $08dc
-        .word   $088d
-        .word   $09e1
-        .word   $0e7c
-        .word   $0b6d
+        .word   $0a8c           ; BASS_DRUM
+        .word   $0bd9           ; SNARE
+        .word   $1194           ; HARD_SNARE
+        .word   $05fa           ; CYMBAL
+        .word   $15f9           ; TOM
+        .word   $0465           ; CLOSED_HIHAT
+        .word   $1194           ; OPEN_HIHAT
+        .word   $1194           ; TIMPANI
+        .word   $04f5           ; VIBRAPHONE
+        .word   $029a           ; MARIMBA
+        .word   $08f7           ; STRINGS
+        .word   $02c7           ; CHOIR
+        .word   $034e           ; HARP
+        .word   $04da           ; TRUMPET
+        .word   $0252           ; OBOE
+        .word   $0489           ; FLUTE
+        .word   $0936           ; ORGAN
+        .word   $0642           ; PIANO
+        .word   $0144           ; ELECTRIC_BASS
+        .word   $044a           ; BASS_GUITAR
+        .word   $05bb           ; GRAND_PIANO
+        .word   $0666           ; MUSIC_BOX_INSTR
+        .word   $1194           ; WOO
+        .word   $09bd           ; METAL_SYSTEM
+        .word   $0384           ; SYNTH_CHORD
+        .word   $05bb           ; DIST_GUITAR
+        .word   $092d           ; KRABI
+        .word   $15f9           ; HORN
+        .word   $0318           ; MANDOLIN
+        .word   $077d           ; UNKNOWN_1
+        .word   $08dc           ; CONGA
+        .word   $088d           ; CASABA
+        .word   $09e1           ; KLAVES
+        .word   $0e7c           ; UNKNOWN_2
+        .word   $0b6d           ; HAND_CLAP
 
 ; ---------------------------------------------------------------------------
 
 ; c4/3d1e
 SampleFreqMult:
-        .byte   $c0,$00
-        .byte   $00,$00
-        .byte   $c0,$00
-        .byte   $00,$00
-        .byte   $60,$00
-        .byte   $00,$00
-        .byte   $00,$00
-        .byte   $fb,$00
-        .byte   $fe,$48
-        .byte   $e0,$a0
-        .byte   $00,$7c
-        .byte   $fd,$00
-        .byte   $51,$00
-        .byte   $fe,$00
-        .byte   $e0,$90
-        .byte   $fc,$60
-        .byte   $fc,$7f
-        .byte   $ff,$00
-        .byte   $fc,$c0
-        .byte   $fc,$a0
-        .byte   $fc,$d0
-        .byte   $ff,$a0
-        .byte   $00,$00
-        .byte   $00,$00
-        .byte   $00,$00
-        .byte   $00,$00
-        .byte   $fe,$00
-        .byte   $e0,$b0
-        .byte   $fc,$90
-        .byte   $e0,$c0
-        .byte   $00,$00
-        .byte   $00,$00
-        .byte   $0e,$00
-        .byte   $00,$00
-        .byte   $00,$00
+        .byte   $c0,$00         ; BASS_DRUM
+        .byte   $00,$00         ; SNARE
+        .byte   $c0,$00         ; HARD_SNARE
+        .byte   $00,$00         ; CYMBAL
+        .byte   $60,$00         ; TOM
+        .byte   $00,$00         ; CLOSED_HIHAT
+        .byte   $00,$00         ; OPEN_HIHAT
+        .byte   $fb,$00         ; TIMPANI
+        .byte   $fe,$48         ; VIBRAPHONE
+        .byte   $e0,$a0         ; MARIMBA
+        .byte   $00,$7c         ; STRINGS
+        .byte   $fd,$00         ; CHOIR
+        .byte   $51,$00         ; HARP
+        .byte   $fe,$00         ; TRUMPET
+        .byte   $e0,$90         ; OBOE
+        .byte   $fc,$60         ; FLUTE
+        .byte   $fc,$7f         ; ORGAN
+        .byte   $ff,$00         ; PIANO
+        .byte   $fc,$c0         ; ELECTRIC_BASS
+        .byte   $fc,$a0         ; BASS_GUITAR
+        .byte   $fc,$d0         ; GRAND_PIANO
+        .byte   $ff,$a0         ; MUSIC_BOX_INSTR
+        .byte   $00,$00         ; WOO
+        .byte   $00,$00         ; METAL_SYSTEM
+        .byte   $00,$00         ; SYNTH_CHORD
+        .byte   $00,$00         ; DIST_GUITAR
+        .byte   $fe,$00         ; KRABI
+        .byte   $e0,$b0         ; HORN
+        .byte   $fc,$90         ; MANDOLIN
+        .byte   $e0,$c0         ; UNKNOWN_1
+        .byte   $00,$00         ; CONGA
+        .byte   $00,$00         ; CASABA
+        .byte   $0e,$00         ; KLAVES
+        .byte   $00,$00         ; UNKNOWN_2
+        .byte   $00,$00         ; HAND_CLAP
 
 ; ---------------------------------------------------------------------------
 
 ; c4/3d64
 SampleADSR:
-        make_adsr 15,15,7,0
-        make_adsr 15,15,7,0
-        make_adsr 15,15,7,0
-        make_adsr 15,15,7,16
-        make_adsr 15,15,7,0
-        make_adsr 15,15,7,0
-        make_adsr 15,15,7,0
-        make_adsr 15,15,7,0
-        make_adsr 15,15,7,16
-        make_adsr 15,15,7,21
-        make_adsr 15,15,7,0
-        make_adsr 15,15,7,0
-        make_adsr 15,15,7,18
-        make_adsr 15,15,7,1
-        make_adsr 15,15,7,1
-        make_adsr 15,15,7,1
-        make_adsr 15,15,7,0
-        make_adsr 15,15,7,13
-        make_adsr 15,15,7,0
-        make_adsr 15,15,7,12
-        make_adsr 15,15,7,10
-        make_adsr 15,15,7,19
-        make_adsr 15,15,7,0
-        make_adsr 15,15,7,10
-        make_adsr 15,15,7,10
-        make_adsr 15,15,7,8
-        make_adsr 15,15,7,19
-        make_adsr 15,15,7,1
-        make_adsr 15,15,7,17
-        make_adsr 15,15,7,20
-        make_adsr 15,15,7,19
-        make_adsr 15,15,7,0
-        make_adsr 15,15,7,0
-        make_adsr 15,15,7,0
-        make_adsr 15,15,7,0
+        make_adsr 15,15,7,0    ; BASS_DRUM
+        make_adsr 15,15,7,0    ; SNARE
+        make_adsr 15,15,7,0    ; HARD_SNARE
+        make_adsr 15,15,7,16   ; CYMBAL
+        make_adsr 15,15,7,0    ; TOM
+        make_adsr 15,15,7,0    ; CLOSED_HIHAT
+        make_adsr 15,15,7,0    ; OPEN_HIHAT
+        make_adsr 15,15,7,0    ; TIMPANI
+        make_adsr 15,15,7,16   ; VIBRAPHONE
+        make_adsr 15,15,7,21   ; MARIMBA
+        make_adsr 15,15,7,0    ; STRINGS
+        make_adsr 15,15,7,0    ; CHOIR
+        make_adsr 15,15,7,18   ; HARP
+        make_adsr 15,15,7,1    ; TRUMPET
+        make_adsr 15,15,7,1    ; OBOE
+        make_adsr 15,15,7,1    ; FLUTE
+        make_adsr 15,15,7,0    ; ORGAN
+        make_adsr 15,15,7,13   ; PIANO
+        make_adsr 15,15,7,0    ; ELECTRIC_BASS
+        make_adsr 15,15,7,12   ; BASS_GUITAR
+        make_adsr 15,15,7,10   ; GRAND_PIANO
+        make_adsr 15,15,7,19   ; MUSIC_BOX_INSTR
+        make_adsr 15,15,7,0    ; WOO
+        make_adsr 15,15,7,10   ; METAL_SYSTEM
+        make_adsr 15,15,7,10   ; SYNTH_CHORD
+        make_adsr 15,15,7,8    ; DIST_GUITAR
+        make_adsr 15,15,7,19   ; KRABI
+        make_adsr 15,15,7,1    ; HORN
+        make_adsr 15,15,7,17   ; MANDOLIN
+        make_adsr 15,15,7,20   ; UNKNOWN_1
+        make_adsr 15,15,7,19   ; CONGA
+        make_adsr 15,15,7,0    ; CASABA
+        make_adsr 15,15,7,0    ; KLAVES
+        make_adsr 15,15,7,0    ; UNKNOWN_2
+        make_adsr 15,15,7,0    ; HAND_CLAP
 
 ; ---------------------------------------------------------------------------
 

--- a/src/sound/song-data.asm
+++ b/src/sound/song-data.asm
@@ -144,606 +144,606 @@ SampleADSR:
 SongSamples:
 
         begin_song_samples 0
-        def_song_sample $0f
-        def_song_sample $0e
-        def_song_sample $0b
-        def_song_sample $14
-        def_song_sample $06
-        def_song_sample $07
-        def_song_sample $01
-        def_song_sample $02
-        def_song_sample $0d
-        def_song_sample $04
+        def_song_sample OBOE
+        def_song_sample TRUMPET
+        def_song_sample STRINGS
+        def_song_sample BASS_GUITAR
+        def_song_sample CLOSED_HIHAT
+        def_song_sample OPEN_HIHAT
+        def_song_sample BASS_DRUM
+        def_song_sample SNARE
+        def_song_sample HARP
+        def_song_sample CYMBAL
         end_song_samples 0
 
         begin_song_samples 1
-        def_song_sample $08
-        def_song_sample $0e
-        def_song_sample $14
-        def_song_sample $0b
-        def_song_sample $04
-        def_song_sample $02
+        def_song_sample TIMPANI
+        def_song_sample TRUMPET
+        def_song_sample BASS_GUITAR
+        def_song_sample STRINGS
+        def_song_sample CYMBAL
+        def_song_sample SNARE
         end_song_samples 1
 
         begin_song_samples 2
-        def_song_sample $0f
-        def_song_sample $10
-        def_song_sample $0b
-        def_song_sample $15
-        def_song_sample $1c
-        def_song_sample $16
-        def_song_sample $0c
-        def_song_sample $19
-        def_song_sample $04
+        def_song_sample OBOE
+        def_song_sample FLUTE
+        def_song_sample STRINGS
+        def_song_sample GRAND_PIANO
+        def_song_sample HORN
+        def_song_sample MUSIC_BOX_INSTR
+        def_song_sample CHOIR
+        def_song_sample SYNTH_CHORD
+        def_song_sample CYMBAL
         end_song_samples 2
 
         begin_song_samples 3
-        def_song_sample $0f
-        def_song_sample $0a
-        def_song_sample $14
-        def_song_sample $0e
-        def_song_sample $06
-        def_song_sample $07
-        def_song_sample $01
-        def_song_sample $02
-        def_song_sample $05
+        def_song_sample OBOE
+        def_song_sample MARIMBA
+        def_song_sample BASS_GUITAR
+        def_song_sample TRUMPET
+        def_song_sample CLOSED_HIHAT
+        def_song_sample OPEN_HIHAT
+        def_song_sample BASS_DRUM
+        def_song_sample SNARE
+        def_song_sample TOM
         end_song_samples 3
 
         begin_song_samples 4
-        def_song_sample $0f
-        def_song_sample $10
-        def_song_sample $0e
-        def_song_sample $1d
-        def_song_sample $14
-        def_song_sample $08
+        def_song_sample OBOE
+        def_song_sample FLUTE
+        def_song_sample TRUMPET
+        def_song_sample MANDOLIN
+        def_song_sample BASS_GUITAR
+        def_song_sample TIMPANI
         end_song_samples 4
 
         begin_song_samples 5
-        def_song_sample $0d
-        def_song_sample $0f
-        def_song_sample $1c
-        def_song_sample $0b
-        def_song_sample $1d
+        def_song_sample HARP
+        def_song_sample OBOE
+        def_song_sample HORN
+        def_song_sample STRINGS
+        def_song_sample MANDOLIN
         end_song_samples 5
 
         begin_song_samples 6
-        def_song_sample $10
-        def_song_sample $0d
-        def_song_sample $0b
-        def_song_sample $14
-        def_song_sample $05
-        def_song_sample $20
-        def_song_sample $1f
-        def_song_sample $04
+        def_song_sample FLUTE
+        def_song_sample HARP
+        def_song_sample STRINGS
+        def_song_sample BASS_GUITAR
+        def_song_sample TOM
+        def_song_sample CASABA
+        def_song_sample CONGA
+        def_song_sample CYMBAL
         end_song_samples 6
 
         begin_song_samples 7
-        def_song_sample $0f
-        def_song_sample $10
-        def_song_sample $0a
-        def_song_sample $08
-        def_song_sample $14
+        def_song_sample OBOE
+        def_song_sample FLUTE
+        def_song_sample MARIMBA
+        def_song_sample TIMPANI
+        def_song_sample BASS_GUITAR
         end_song_samples 7
 
         begin_song_samples 8
-        def_song_sample $0d
-        def_song_sample $0b
-        def_song_sample $0f
-        def_song_sample $1c
+        def_song_sample HARP
+        def_song_sample STRINGS
+        def_song_sample OBOE
+        def_song_sample HORN
         end_song_samples 8
 
         begin_song_samples 9
-        def_song_sample $0e
-        def_song_sample $0b
-        def_song_sample $14
-        def_song_sample $04
-        def_song_sample $10
-        def_song_sample $06
-        def_song_sample $07
-        def_song_sample $01
-        def_song_sample $03
+        def_song_sample TRUMPET
+        def_song_sample STRINGS
+        def_song_sample BASS_GUITAR
+        def_song_sample CYMBAL
+        def_song_sample FLUTE
+        def_song_sample CLOSED_HIHAT
+        def_song_sample OPEN_HIHAT
+        def_song_sample BASS_DRUM
+        def_song_sample HARD_SNARE
         end_song_samples 9
 
         begin_song_samples 10
-        def_song_sample $10
-        def_song_sample $0b
+        def_song_sample FLUTE
+        def_song_sample STRINGS
         end_song_samples 10
 
         begin_song_samples 11
-        def_song_sample $12
-        def_song_sample $0c
-        def_song_sample $0b
-        def_song_sample $16
+        def_song_sample PIANO
+        def_song_sample CHOIR
+        def_song_sample STRINGS
+        def_song_sample MUSIC_BOX_INSTR
         end_song_samples 11
 
         begin_song_samples 12
-        def_song_sample $0f
-        def_song_sample $0b
-        def_song_sample $15
-        def_song_sample $05
-        def_song_sample $08
-        def_song_sample $18
+        def_song_sample OBOE
+        def_song_sample STRINGS
+        def_song_sample GRAND_PIANO
+        def_song_sample TOM
+        def_song_sample TIMPANI
+        def_song_sample METAL_SYSTEM
         end_song_samples 12
 
         begin_song_samples 13
-        def_song_sample $10
-        def_song_sample $0b
-        def_song_sample $16
-        def_song_sample $14
-        def_song_sample $09
+        def_song_sample FLUTE
+        def_song_sample STRINGS
+        def_song_sample MUSIC_BOX_INSTR
+        def_song_sample BASS_GUITAR
+        def_song_sample VIBRAPHONE
         end_song_samples 13
 
         begin_song_samples 14
-        def_song_sample $0e
-        def_song_sample $14
-        def_song_sample $02
-        def_song_sample $01
-        def_song_sample $11
+        def_song_sample TRUMPET
+        def_song_sample BASS_GUITAR
+        def_song_sample SNARE
+        def_song_sample BASS_DRUM
+        def_song_sample ORGAN
         end_song_samples 14
 
         begin_song_samples 15
-        def_song_sample $0d
-        def_song_sample $0b
-        def_song_sample $10
+        def_song_sample HARP
+        def_song_sample STRINGS
+        def_song_sample FLUTE
         end_song_samples 15
 
         begin_song_samples 16
-        def_song_sample $0f
-        def_song_sample $0d
-        def_song_sample $0b
-        def_song_sample $14
-        def_song_sample $0c
+        def_song_sample OBOE
+        def_song_sample HARP
+        def_song_sample STRINGS
+        def_song_sample BASS_GUITAR
+        def_song_sample CHOIR
         end_song_samples 16
 
         begin_song_samples 17
         end_song_samples 17
 
         begin_song_samples 18
-        def_song_sample $0b
-        def_song_sample $14
-        def_song_sample $0e
-        def_song_sample $11
-        def_song_sample $04
-        def_song_sample $08
+        def_song_sample STRINGS
+        def_song_sample BASS_GUITAR
+        def_song_sample TRUMPET
+        def_song_sample ORGAN
+        def_song_sample CYMBAL
+        def_song_sample TIMPANI
         end_song_samples 18
 
         begin_song_samples 19
-        def_song_sample $10
-        def_song_sample $12
-        def_song_sample $0b
-        def_song_sample $1d
+        def_song_sample FLUTE
+        def_song_sample PIANO
+        def_song_sample STRINGS
+        def_song_sample MANDOLIN
         end_song_samples 19
 
         begin_song_samples 20
-        def_song_sample $0b
-        def_song_sample $10
-        def_song_sample $0f
-        def_song_sample $02
-        def_song_sample $1c
-        def_song_sample $08
+        def_song_sample STRINGS
+        def_song_sample FLUTE
+        def_song_sample OBOE
+        def_song_sample SNARE
+        def_song_sample HORN
+        def_song_sample TIMPANI
         end_song_samples 20
 
         begin_song_samples 21
-        def_song_sample $0f
-        def_song_sample $21
-        def_song_sample $0b
-        def_song_sample $14
-        def_song_sample $08
-        def_song_sample $1b
-        def_song_sample $0d
-        def_song_sample $1c
+        def_song_sample OBOE
+        def_song_sample KLAVES
+        def_song_sample STRINGS
+        def_song_sample BASS_GUITAR
+        def_song_sample TIMPANI
+        def_song_sample KRABI
+        def_song_sample HARP
+        def_song_sample HORN
         end_song_samples 21
 
         begin_song_samples 22
-        def_song_sample $0e
-        def_song_sample $0b
-        def_song_sample $14
-        def_song_sample $08
-        def_song_sample $02
-        def_song_sample $04
+        def_song_sample TRUMPET
+        def_song_sample STRINGS
+        def_song_sample BASS_GUITAR
+        def_song_sample TIMPANI
+        def_song_sample SNARE
+        def_song_sample CYMBAL
         end_song_samples 22
 
         begin_song_samples 23
-        def_song_sample $0b
-        def_song_sample $14
-        def_song_sample $04
-        def_song_sample $01
-        def_song_sample $03
+        def_song_sample STRINGS
+        def_song_sample BASS_GUITAR
+        def_song_sample CYMBAL
+        def_song_sample BASS_DRUM
+        def_song_sample HARD_SNARE
         end_song_samples 23
 
         begin_song_samples 24
-        def_song_sample $14
-        def_song_sample $0b
-        def_song_sample $02
-        def_song_sample $0e
-        def_song_sample $04
+        def_song_sample BASS_GUITAR
+        def_song_sample STRINGS
+        def_song_sample SNARE
+        def_song_sample TRUMPET
+        def_song_sample CYMBAL
         end_song_samples 24
 
         begin_song_samples 25
-        def_song_sample $0b
-        def_song_sample $0f
-        def_song_sample $0d
-        def_song_sample $10
+        def_song_sample STRINGS
+        def_song_sample OBOE
+        def_song_sample HARP
+        def_song_sample FLUTE
         end_song_samples 25
 
         begin_song_samples 26
-        def_song_sample $0e
-        def_song_sample $1e
-        def_song_sample $14
-        def_song_sample $21
-        def_song_sample $17
-        def_song_sample $20
-        def_song_sample $22
-        def_song_sample $1f
+        def_song_sample TRUMPET
+        def_song_sample UNKNOWN_1
+        def_song_sample BASS_GUITAR
+        def_song_sample KLAVES
+        def_song_sample WOO
+        def_song_sample CASABA
+        def_song_sample UNKNOWN_2
+        def_song_sample CONGA
         end_song_samples 26
 
         begin_song_samples 27
-        def_song_sample $16
+        def_song_sample MUSIC_BOX_INSTR
         end_song_samples 27
 
         begin_song_samples 28
-        def_song_sample $0f
-        def_song_sample $0d
-        def_song_sample $0b
-        def_song_sample $14
-        def_song_sample $13
-        def_song_sample $21
-        def_song_sample $04
+        def_song_sample OBOE
+        def_song_sample HARP
+        def_song_sample STRINGS
+        def_song_sample BASS_GUITAR
+        def_song_sample ELECTRIC_BASS
+        def_song_sample KLAVES
+        def_song_sample CYMBAL
         end_song_samples 28
 
         begin_song_samples 29
-        def_song_sample $0e
-        def_song_sample $0d
-        def_song_sample $14
-        def_song_sample $0b
-        def_song_sample $06
-        def_song_sample $01
-        def_song_sample $02
+        def_song_sample TRUMPET
+        def_song_sample HARP
+        def_song_sample BASS_GUITAR
+        def_song_sample STRINGS
+        def_song_sample CLOSED_HIHAT
+        def_song_sample BASS_DRUM
+        def_song_sample SNARE
         end_song_samples 29
 
         begin_song_samples 30
-        def_song_sample $10
-        def_song_sample $0d
-        def_song_sample $0b
+        def_song_sample FLUTE
+        def_song_sample HARP
+        def_song_sample STRINGS
         end_song_samples 30
 
         begin_song_samples 31
-        def_song_sample $01
-        def_song_sample $14
-        def_song_sample $0b
-        def_song_sample $0e
-        def_song_sample $10
-        def_song_sample $21
-        def_song_sample $23
-        def_song_sample $04
+        def_song_sample BASS_DRUM
+        def_song_sample BASS_GUITAR
+        def_song_sample STRINGS
+        def_song_sample TRUMPET
+        def_song_sample FLUTE
+        def_song_sample KLAVES
+        def_song_sample HAND_CLAP
+        def_song_sample CYMBAL
         end_song_samples 31
 
         begin_song_samples 32
-        def_song_sample $0e
-        def_song_sample $0b
-        def_song_sample $14
-        def_song_sample $02
-        def_song_sample $04
-        def_song_sample $08
+        def_song_sample TRUMPET
+        def_song_sample STRINGS
+        def_song_sample BASS_GUITAR
+        def_song_sample SNARE
+        def_song_sample CYMBAL
+        def_song_sample TIMPANI
         end_song_samples 32
 
         begin_song_samples 33
-        def_song_sample $0f
-        def_song_sample $23
-        def_song_sample $10
-        def_song_sample $13
-        def_song_sample $1d
-        def_song_sample $05
+        def_song_sample OBOE
+        def_song_sample HAND_CLAP
+        def_song_sample FLUTE
+        def_song_sample ELECTRIC_BASS
+        def_song_sample MANDOLIN
+        def_song_sample TOM
         end_song_samples 33
 
         begin_song_samples 34
-        def_song_sample $11
-        def_song_sample $0e
-        def_song_sample $14
-        def_song_sample $1a
-        def_song_sample $04
-        def_song_sample $06
-        def_song_sample $07
-        def_song_sample $01
-        def_song_sample $03
-        def_song_sample $05
+        def_song_sample ORGAN
+        def_song_sample TRUMPET
+        def_song_sample BASS_GUITAR
+        def_song_sample DIST_GUITAR
+        def_song_sample CYMBAL
+        def_song_sample CLOSED_HIHAT
+        def_song_sample OPEN_HIHAT
+        def_song_sample BASS_DRUM
+        def_song_sample HARD_SNARE
+        def_song_sample TOM
         end_song_samples 34
 
         begin_song_samples 35
-        def_song_sample $10
-        def_song_sample $0b
-        def_song_sample $08
-        def_song_sample $14
-        def_song_sample $02
-        def_song_sample $0d
-        def_song_sample $04
-        def_song_sample $1c
-        def_song_sample $0e
+        def_song_sample FLUTE
+        def_song_sample STRINGS
+        def_song_sample TIMPANI
+        def_song_sample BASS_GUITAR
+        def_song_sample SNARE
+        def_song_sample HARP
+        def_song_sample CYMBAL
+        def_song_sample HORN
+        def_song_sample TRUMPET
         end_song_samples 35
 
         begin_song_samples 36
-        def_song_sample $0d
-        def_song_sample $09
-        def_song_sample $18
-        def_song_sample $0c
-        def_song_sample $1f
-        def_song_sample $0b
-        def_song_sample $1d
-        def_song_sample $04
+        def_song_sample HARP
+        def_song_sample VIBRAPHONE
+        def_song_sample METAL_SYSTEM
+        def_song_sample CHOIR
+        def_song_sample CONGA
+        def_song_sample STRINGS
+        def_song_sample MANDOLIN
+        def_song_sample CYMBAL
         end_song_samples 36
 
         begin_song_samples 37
-        def_song_sample $05
-        def_song_sample $1f
-        def_song_sample $20
-        def_song_sample $14
-        def_song_sample $09
-        def_song_sample $17
+        def_song_sample TOM
+        def_song_sample CONGA
+        def_song_sample CASABA
+        def_song_sample BASS_GUITAR
+        def_song_sample VIBRAPHONE
+        def_song_sample WOO
         end_song_samples 37
 
         begin_song_samples 38
-        def_song_sample $0b
-        def_song_sample $1b
-        def_song_sample $06
-        def_song_sample $07
-        def_song_sample $1f
-        def_song_sample $01
-        def_song_sample $02
-        def_song_sample $09
-        def_song_sample $14
-        def_song_sample $04
+        def_song_sample STRINGS
+        def_song_sample KRABI
+        def_song_sample CLOSED_HIHAT
+        def_song_sample OPEN_HIHAT
+        def_song_sample CONGA
+        def_song_sample BASS_DRUM
+        def_song_sample SNARE
+        def_song_sample VIBRAPHONE
+        def_song_sample BASS_GUITAR
+        def_song_sample CYMBAL
         end_song_samples 38
 
         begin_song_samples 39
-        def_song_sample $10
-        def_song_sample $0b
-        def_song_sample $0d
-        def_song_sample $14
-        def_song_sample $07
-        def_song_sample $06
-        def_song_sample $01
-        def_song_sample $03
-        def_song_sample $02
+        def_song_sample FLUTE
+        def_song_sample STRINGS
+        def_song_sample HARP
+        def_song_sample BASS_GUITAR
+        def_song_sample OPEN_HIHAT
+        def_song_sample CLOSED_HIHAT
+        def_song_sample BASS_DRUM
+        def_song_sample HARD_SNARE
+        def_song_sample SNARE
         end_song_samples 39
 
         begin_song_samples 40
-        def_song_sample $10
-        def_song_sample $0e
-        def_song_sample $0b
-        def_song_sample $14
-        def_song_sample $04
-        def_song_sample $06
-        def_song_sample $07
-        def_song_sample $08
-        def_song_sample $01
-        def_song_sample $02
+        def_song_sample FLUTE
+        def_song_sample TRUMPET
+        def_song_sample STRINGS
+        def_song_sample BASS_GUITAR
+        def_song_sample CYMBAL
+        def_song_sample CLOSED_HIHAT
+        def_song_sample OPEN_HIHAT
+        def_song_sample TIMPANI
+        def_song_sample BASS_DRUM
+        def_song_sample SNARE
         end_song_samples 40
 
         begin_song_samples 41
-        def_song_sample $0e
-        def_song_sample $08
-        def_song_sample $04
-        def_song_sample $0b
+        def_song_sample TRUMPET
+        def_song_sample TIMPANI
+        def_song_sample CYMBAL
+        def_song_sample STRINGS
         end_song_samples 41
 
         begin_song_samples 42
-        def_song_sample $0e
-        def_song_sample $0b
-        def_song_sample $10
-        def_song_sample $04
-        def_song_sample $02
-        def_song_sample $08
+        def_song_sample TRUMPET
+        def_song_sample STRINGS
+        def_song_sample FLUTE
+        def_song_sample CYMBAL
+        def_song_sample SNARE
+        def_song_sample TIMPANI
         end_song_samples 42
 
         begin_song_samples 43
-        def_song_sample $0b
-        def_song_sample $0e
-        def_song_sample $14
-        def_song_sample $04
-        def_song_sample $06
-        def_song_sample $07
-        def_song_sample $01
-        def_song_sample $02
-        def_song_sample $09
+        def_song_sample STRINGS
+        def_song_sample TRUMPET
+        def_song_sample BASS_GUITAR
+        def_song_sample CYMBAL
+        def_song_sample CLOSED_HIHAT
+        def_song_sample OPEN_HIHAT
+        def_song_sample BASS_DRUM
+        def_song_sample SNARE
+        def_song_sample VIBRAPHONE
         end_song_samples 43
 
         begin_song_samples 44
-        def_song_sample $0e
-        def_song_sample $11
-        def_song_sample $1d
-        def_song_sample $14
-        def_song_sample $1a
-        def_song_sample $04
-        def_song_sample $06
-        def_song_sample $07
-        def_song_sample $01
-        def_song_sample $02
-        def_song_sample $19
+        def_song_sample TRUMPET
+        def_song_sample ORGAN
+        def_song_sample MANDOLIN
+        def_song_sample BASS_GUITAR
+        def_song_sample DIST_GUITAR
+        def_song_sample CYMBAL
+        def_song_sample CLOSED_HIHAT
+        def_song_sample OPEN_HIHAT
+        def_song_sample BASS_DRUM
+        def_song_sample SNARE
+        def_song_sample SYNTH_CHORD
         end_song_samples 44
 
         begin_song_samples 45
-        def_song_sample $0b
-        def_song_sample $0c
-        def_song_sample $14
-        def_song_sample $04
-        def_song_sample $01
-        def_song_sample $03
-        def_song_sample $1a
+        def_song_sample STRINGS
+        def_song_sample CHOIR
+        def_song_sample BASS_GUITAR
+        def_song_sample CYMBAL
+        def_song_sample BASS_DRUM
+        def_song_sample HARD_SNARE
+        def_song_sample DIST_GUITAR
         end_song_samples 45
 
         begin_song_samples 46
-        def_song_sample $0e
-        def_song_sample $0b
-        def_song_sample $14
-        def_song_sample $1c
-        def_song_sample $02
-        def_song_sample $04
+        def_song_sample TRUMPET
+        def_song_sample STRINGS
+        def_song_sample BASS_GUITAR
+        def_song_sample HORN
+        def_song_sample SNARE
+        def_song_sample CYMBAL
         end_song_samples 46
 
         begin_song_samples 47
-        def_song_sample $14
-        def_song_sample $0e
-        def_song_sample $1d
-        def_song_sample $21
-        def_song_sample $23
+        def_song_sample BASS_GUITAR
+        def_song_sample TRUMPET
+        def_song_sample MANDOLIN
+        def_song_sample KLAVES
+        def_song_sample HAND_CLAP
         end_song_samples 47
 
         begin_song_samples 48
         end_song_samples 48
 
         begin_song_samples 49
-        def_song_sample $0e
-        def_song_sample $0b
-        def_song_sample $10
-        def_song_sample $0a
-        def_song_sample $08
-        def_song_sample $04
-        def_song_sample $1c
-        def_song_sample $02
+        def_song_sample TRUMPET
+        def_song_sample STRINGS
+        def_song_sample FLUTE
+        def_song_sample MARIMBA
+        def_song_sample TIMPANI
+        def_song_sample CYMBAL
+        def_song_sample HORN
+        def_song_sample SNARE
         end_song_samples 49
 
         begin_song_samples 50
-        def_song_sample $05
-        def_song_sample $07
-        def_song_sample $02
-        def_song_sample $22
-        def_song_sample $21
-        def_song_sample $0b
-        def_song_sample $14
+        def_song_sample TOM
+        def_song_sample OPEN_HIHAT
+        def_song_sample SNARE
+        def_song_sample UNKNOWN_2
+        def_song_sample KLAVES
+        def_song_sample STRINGS
+        def_song_sample BASS_GUITAR
         end_song_samples 50
 
         begin_song_samples 51
-        def_song_sample $0f
-        def_song_sample $0e
-        def_song_sample $0b
-        def_song_sample $14
-        def_song_sample $0d
-        def_song_sample $02
-        def_song_sample $08
-        def_song_sample $09
+        def_song_sample OBOE
+        def_song_sample TRUMPET
+        def_song_sample STRINGS
+        def_song_sample BASS_GUITAR
+        def_song_sample HARP
+        def_song_sample SNARE
+        def_song_sample TIMPANI
+        def_song_sample VIBRAPHONE
         end_song_samples 51
 
         begin_song_samples 52
         end_song_samples 52
 
         begin_song_samples 53
-        def_song_sample $09
-        def_song_sample $21
-        def_song_sample $09
-        def_song_sample $11
+        def_song_sample VIBRAPHONE
+        def_song_sample KLAVES
+        def_song_sample VIBRAPHONE
+        def_song_sample ORGAN
         end_song_samples 53
 
         begin_song_samples 54
-        def_song_sample $09
-        def_song_sample $21
-        def_song_sample $09
-        def_song_sample $11
+        def_song_sample VIBRAPHONE
+        def_song_sample KLAVES
+        def_song_sample VIBRAPHONE
+        def_song_sample ORGAN
         end_song_samples 54
 
         begin_song_samples 55
-        def_song_sample $09
-        def_song_sample $21
-        def_song_sample $09
-        def_song_sample $11
+        def_song_sample VIBRAPHONE
+        def_song_sample KLAVES
+        def_song_sample VIBRAPHONE
+        def_song_sample ORGAN
         end_song_samples 55
 
         begin_song_samples 56
-        def_song_sample $09
-        def_song_sample $21
-        def_song_sample $09
-        def_song_sample $22
-        def_song_sample $11
+        def_song_sample VIBRAPHONE
+        def_song_sample KLAVES
+        def_song_sample VIBRAPHONE
+        def_song_sample UNKNOWN_2
+        def_song_sample ORGAN
         end_song_samples 56
 
         begin_song_samples 57
-        def_song_sample $09
-        def_song_sample $11
+        def_song_sample VIBRAPHONE
+        def_song_sample ORGAN
         end_song_samples 57
 
         begin_song_samples 58
-        def_song_sample $09
-        def_song_sample $11
+        def_song_sample VIBRAPHONE
+        def_song_sample ORGAN
         end_song_samples 58
 
         begin_song_samples 59
-        def_song_sample $09
-        def_song_sample $11
+        def_song_sample VIBRAPHONE
+        def_song_sample ORGAN
         end_song_samples 59
 
         begin_song_samples 60
-        def_song_sample $09
-        def_song_sample $11
+        def_song_sample VIBRAPHONE
+        def_song_sample ORGAN
         end_song_samples 60
 
         begin_song_samples 61
-        def_song_sample $08
-        def_song_sample $14
-        def_song_sample $04
-        def_song_sample $0b
-        def_song_sample $0e
-        def_song_sample $10
+        def_song_sample TIMPANI
+        def_song_sample BASS_GUITAR
+        def_song_sample CYMBAL
+        def_song_sample STRINGS
+        def_song_sample TRUMPET
+        def_song_sample FLUTE
         end_song_samples 61
 
         begin_song_samples 62
         end_song_samples 62
 
         begin_song_samples 63
-        def_song_sample $1d
-        def_song_sample $0d
-        def_song_sample $0c
-        def_song_sample $0b
-        def_song_sample $14
-        def_song_sample $10
-        def_song_sample $01
-        def_song_sample $20
-        def_song_sample $09
-        def_song_sample $21
+        def_song_sample MANDOLIN
+        def_song_sample HARP
+        def_song_sample CHOIR
+        def_song_sample STRINGS
+        def_song_sample BASS_GUITAR
+        def_song_sample FLUTE
+        def_song_sample BASS_DRUM
+        def_song_sample CASABA
+        def_song_sample VIBRAPHONE
+        def_song_sample KLAVES
         end_song_samples 63
 
         begin_song_samples 64
-        def_song_sample $0b
-        def_song_sample $0e
-        def_song_sample $05
-        def_song_sample $14
-        def_song_sample $04
-        def_song_sample $02
-        def_song_sample $07
-        def_song_sample $06
-        def_song_sample $01
-        def_song_sample $1a
+        def_song_sample STRINGS
+        def_song_sample TRUMPET
+        def_song_sample TOM
+        def_song_sample BASS_GUITAR
+        def_song_sample CYMBAL
+        def_song_sample SNARE
+        def_song_sample OPEN_HIHAT
+        def_song_sample CLOSED_HIHAT
+        def_song_sample BASS_DRUM
+        def_song_sample DIST_GUITAR
         end_song_samples 64
 
         begin_song_samples 65
-        def_song_sample $10
-        def_song_sample $0f
-        def_song_sample $0d
-        def_song_sample $14
-        def_song_sample $0b
+        def_song_sample FLUTE
+        def_song_sample OBOE
+        def_song_sample HARP
+        def_song_sample BASS_GUITAR
+        def_song_sample STRINGS
         end_song_samples 65
 
         begin_song_samples 66
-        def_song_sample $1d
-        def_song_sample $10
+        def_song_sample MANDOLIN
+        def_song_sample FLUTE
         end_song_samples 66
 
         begin_song_samples 67
-        def_song_sample $1c
-        def_song_sample $0b
-        def_song_sample $0d
-        def_song_sample $16
-        def_song_sample $10
-        def_song_sample $09
+        def_song_sample HORN
+        def_song_sample STRINGS
+        def_song_sample HARP
+        def_song_sample MUSIC_BOX_INSTR
+        def_song_sample FLUTE
+        def_song_sample VIBRAPHONE
         end_song_samples 67
 
         begin_song_samples 68
-        def_song_sample $0b
-        def_song_sample $0e
-        def_song_sample $1c
-        def_song_sample $04
-        def_song_sample $02
-        def_song_sample $08
-        def_song_sample $10
-        def_song_sample $0d
+        def_song_sample STRINGS
+        def_song_sample TRUMPET
+        def_song_sample HORN
+        def_song_sample CYMBAL
+        def_song_sample SNARE
+        def_song_sample TIMPANI
+        def_song_sample FLUTE
+        def_song_sample HARP
         end_song_samples 68
 
         begin_song_samples 69

--- a/src/sound/song-data.asm
+++ b/src/sound/song-data.asm
@@ -143,6 +143,7 @@ SampleADSR:
 
 SongSamples:
 
+; 00 Ahead on Our Way
         begin_song_samples 0
         def_song_sample OBOE
         def_song_sample TRUMPET
@@ -156,6 +157,7 @@ SongSamples:
         def_song_sample CYMBAL
         end_song_samples 0
 
+; 01 The Fierce Battle
         begin_song_samples 1
         def_song_sample TIMPANI
         def_song_sample TRUMPET
@@ -165,6 +167,7 @@ SongSamples:
         def_song_sample SNARE
         end_song_samples 1
 
+; 02 A Presentiment
         begin_song_samples 2
         def_song_sample OBOE
         def_song_sample FLUTE
@@ -177,6 +180,7 @@ SongSamples:
         def_song_sample CYMBAL
         end_song_samples 2
 
+; 03 Go Go Boko!
         begin_song_samples 3
         def_song_sample OBOE
         def_song_sample MARIMBA
@@ -189,6 +193,7 @@ SongSamples:
         def_song_sample TOM
         end_song_samples 3
 
+; 04 Pirates Ahoy!
         begin_song_samples 4
         def_song_sample OBOE
         def_song_sample FLUTE
@@ -198,6 +203,7 @@ SongSamples:
         def_song_sample TIMPANI
         end_song_samples 4
 
+; 05 Tenderness in the Air
         begin_song_samples 5
         def_song_sample HARP
         def_song_sample OBOE
@@ -206,6 +212,7 @@ SongSamples:
         def_song_sample MANDOLIN
         end_song_samples 5
 
+; 06 Fate in Haze
         begin_song_samples 6
         def_song_sample FLUTE
         def_song_sample HARP
@@ -217,6 +224,7 @@ SongSamples:
         def_song_sample CYMBAL
         end_song_samples 6
 
+; 07 Critter Tripper Fritter!
         begin_song_samples 7
         def_song_sample OBOE
         def_song_sample FLUTE
@@ -225,6 +233,7 @@ SongSamples:
         def_song_sample BASS_GUITAR
         end_song_samples 7
 
+; 08 The Prelude
         begin_song_samples 8
         def_song_sample HARP
         def_song_sample STRINGS
@@ -232,6 +241,7 @@ SongSamples:
         def_song_sample HORN
         end_song_samples 8
 
+; 09 The Last Battle
         begin_song_samples 9
         def_song_sample TRUMPET
         def_song_sample STRINGS
@@ -244,11 +254,13 @@ SongSamples:
         def_song_sample HARD_SNARE
         end_song_samples 9
 
+; 0A Requiem
         begin_song_samples 10
         def_song_sample FLUTE
         def_song_sample STRINGS
         end_song_samples 10
 
+; 0B Nostalgia
         begin_song_samples 11
         def_song_sample PIANO
         def_song_sample CHOIR
@@ -256,6 +268,7 @@ SongSamples:
         def_song_sample MUSIC_BOX_INSTR
         end_song_samples 11
 
+; 0C Cursed Earths
         begin_song_samples 12
         def_song_sample OBOE
         def_song_sample STRINGS
@@ -265,6 +278,7 @@ SongSamples:
         def_song_sample METAL_SYSTEM
         end_song_samples 12
 
+; 0D Lenna's Theme
         begin_song_samples 13
         def_song_sample FLUTE
         def_song_sample STRINGS
@@ -273,6 +287,7 @@ SongSamples:
         def_song_sample VIBRAPHONE
         end_song_samples 13
 
+; 0E Victory's Fanfare
         begin_song_samples 14
         def_song_sample TRUMPET
         def_song_sample BASS_GUITAR
@@ -281,12 +296,14 @@ SongSamples:
         def_song_sample ORGAN
         end_song_samples 14
 
+; 0F Deception
         begin_song_samples 15
         def_song_sample HARP
         def_song_sample STRINGS
         def_song_sample FLUTE
         end_song_samples 15
 
+; 10 The Day will Come
         begin_song_samples 16
         def_song_sample OBOE
         def_song_sample HARP
@@ -295,9 +312,11 @@ SongSamples:
         def_song_sample CHOIR
         end_song_samples 16
 
+; 11 ...silence
         begin_song_samples 17
         end_song_samples 17
 
+; 12 Exdeath's Castle
         begin_song_samples 18
         def_song_sample STRINGS
         def_song_sample BASS_GUITAR
@@ -307,6 +326,7 @@ SongSamples:
         def_song_sample TIMPANI
         end_song_samples 18
 
+; 13 My Home, Sweet Home
         begin_song_samples 19
         def_song_sample FLUTE
         def_song_sample PIANO
@@ -314,6 +334,7 @@ SongSamples:
         def_song_sample MANDOLIN
         end_song_samples 19
 
+; 14 Waltz Suomi
         begin_song_samples 20
         def_song_sample STRINGS
         def_song_sample FLUTE
@@ -323,6 +344,7 @@ SongSamples:
         def_song_sample TIMPANI
         end_song_samples 20
 
+; 15 Sealed Away
         begin_song_samples 21
         def_song_sample OBOE
         def_song_sample KLAVES
@@ -334,6 +356,7 @@ SongSamples:
         def_song_sample HORN
         end_song_samples 21
 
+; 16 The Four Warriors of Dawn
         begin_song_samples 22
         def_song_sample TRUMPET
         def_song_sample STRINGS
@@ -343,6 +366,7 @@ SongSamples:
         def_song_sample CYMBAL
         end_song_samples 22
 
+; 17 Danger!
         begin_song_samples 23
         def_song_sample STRINGS
         def_song_sample BASS_GUITAR
@@ -351,6 +375,7 @@ SongSamples:
         def_song_sample HARD_SNARE
         end_song_samples 23
 
+; 18 The Fire-Powered Ship
         begin_song_samples 24
         def_song_sample BASS_GUITAR
         def_song_sample STRINGS
@@ -359,6 +384,7 @@ SongSamples:
         def_song_sample CYMBAL
         end_song_samples 24
 
+; 19 As I Feel, You Feel
         begin_song_samples 25
         def_song_sample STRINGS
         def_song_sample OBOE
@@ -366,6 +392,7 @@ SongSamples:
         def_song_sample FLUTE
         end_song_samples 25
 
+; 1A Mambo de Chocobo!
         begin_song_samples 26
         def_song_sample TRUMPET
         def_song_sample UNKNOWN_1
@@ -377,10 +404,12 @@ SongSamples:
         def_song_sample CONGA
         end_song_samples 26
 
+; 1B Music Box
         begin_song_samples 27
         def_song_sample MUSIC_BOX_INSTR
         end_song_samples 27
 
+; 1C Intension of the Earth
         begin_song_samples 28
         def_song_sample OBOE
         def_song_sample HARP
@@ -391,6 +420,7 @@ SongSamples:
         def_song_sample CYMBAL
         end_song_samples 28
 
+; 1D The Dragon Spreads its Wings
         begin_song_samples 29
         def_song_sample TRUMPET
         def_song_sample HARP
@@ -401,12 +431,14 @@ SongSamples:
         def_song_sample SNARE
         end_song_samples 29
 
+; 1E Beyond the Deep Blue Sea
         begin_song_samples 30
         def_song_sample FLUTE
         def_song_sample HARP
         def_song_sample STRINGS
         end_song_samples 30
 
+; 1F Prelude of Empty Skies
         begin_song_samples 31
         def_song_sample BASS_DRUM
         def_song_sample BASS_GUITAR
@@ -418,6 +450,7 @@ SongSamples:
         def_song_sample CYMBAL
         end_song_samples 31
 
+; 20 Searching the Light
         begin_song_samples 32
         def_song_sample TRUMPET
         def_song_sample STRINGS
@@ -427,6 +460,7 @@ SongSamples:
         def_song_sample TIMPANI
         end_song_samples 32
 
+; 21 Harvest
         begin_song_samples 33
         def_song_sample OBOE
         def_song_sample HAND_CLAP
@@ -436,6 +470,7 @@ SongSamples:
         def_song_sample TOM
         end_song_samples 33
 
+; 22 Gilgamesh
         begin_song_samples 34
         def_song_sample ORGAN
         def_song_sample TRUMPET
@@ -449,6 +484,7 @@ SongSamples:
         def_song_sample TOM
         end_song_samples 34
 
+; 23 Four Valiant Hearts
         begin_song_samples 35
         def_song_sample FLUTE
         def_song_sample STRINGS
@@ -461,6 +497,7 @@ SongSamples:
         def_song_sample TRUMPET
         end_song_samples 35
 
+; 24 The Book of Sealings
         begin_song_samples 36
         def_song_sample HARP
         def_song_sample VIBRAPHONE
@@ -472,6 +509,7 @@ SongSamples:
         def_song_sample CYMBAL
         end_song_samples 36
 
+; 25 What?
         begin_song_samples 37
         def_song_sample TOM
         def_song_sample CONGA
@@ -481,6 +519,7 @@ SongSamples:
         def_song_sample WOO
         end_song_samples 37
 
+; 26 Hurry! Hurry!
         begin_song_samples 38
         def_song_sample STRINGS
         def_song_sample KRABI
@@ -494,6 +533,7 @@ SongSamples:
         def_song_sample CYMBAL
         end_song_samples 38
 
+; 27 Unknown Lands
         begin_song_samples 39
         def_song_sample FLUTE
         def_song_sample STRINGS
@@ -506,6 +546,7 @@ SongSamples:
         def_song_sample SNARE
         end_song_samples 39
 
+; 28 The Airship
         begin_song_samples 40
         def_song_sample FLUTE
         def_song_sample TRUMPET
@@ -519,6 +560,7 @@ SongSamples:
         def_song_sample SNARE
         end_song_samples 40
 
+; 29 Fanfare #1
         begin_song_samples 41
         def_song_sample TRUMPET
         def_song_sample TIMPANI
@@ -526,6 +568,7 @@ SongSamples:
         def_song_sample STRINGS
         end_song_samples 41
 
+; 2A Fanfare #2
         begin_song_samples 42
         def_song_sample TRUMPET
         def_song_sample STRINGS
@@ -535,6 +578,7 @@ SongSamples:
         def_song_sample TIMPANI
         end_song_samples 42
 
+; 2B The Battle
         begin_song_samples 43
         def_song_sample STRINGS
         def_song_sample TRUMPET
@@ -547,6 +591,7 @@ SongSamples:
         def_song_sample VIBRAPHONE
         end_song_samples 43
 
+; 2C Walking the Snowy Mountains
         begin_song_samples 44
         def_song_sample TRUMPET
         def_song_sample ORGAN
@@ -561,6 +606,7 @@ SongSamples:
         def_song_sample SYNTH_CHORD
         end_song_samples 44
 
+; 2D The Evil Lord, Exdeath
         begin_song_samples 45
         def_song_sample STRINGS
         def_song_sample CHOIR
@@ -571,6 +617,7 @@ SongSamples:
         def_song_sample DIST_GUITAR
         end_song_samples 45
 
+; 2E The Castle of Dawn
         begin_song_samples 46
         def_song_sample TRUMPET
         def_song_sample STRINGS
@@ -580,6 +627,7 @@ SongSamples:
         def_song_sample CYMBAL
         end_song_samples 46
 
+; 2F I'm a Dancer
         begin_song_samples 47
         def_song_sample BASS_GUITAR
         def_song_sample TRUMPET
@@ -588,9 +636,11 @@ SongSamples:
         def_song_sample HAND_CLAP
         end_song_samples 47
 
+; 30 Reminiscence
         begin_song_samples 48
         end_song_samples 48
 
+; 31 Run!
         begin_song_samples 49
         def_song_sample TRUMPET
         def_song_sample STRINGS
@@ -602,6 +652,7 @@ SongSamples:
         def_song_sample SNARE
         end_song_samples 49
 
+; 32 The Ancient Library
         begin_song_samples 50
         def_song_sample TOM
         def_song_sample OPEN_HIHAT
@@ -612,6 +663,7 @@ SongSamples:
         def_song_sample BASS_GUITAR
         end_song_samples 50
 
+; 33 Royal Palace
         begin_song_samples 51
         def_song_sample OBOE
         def_song_sample TRUMPET
@@ -623,9 +675,11 @@ SongSamples:
         def_song_sample VIBRAPHONE
         end_song_samples 51
 
+; 34 Good Night!
         begin_song_samples 52
         end_song_samples 52
 
+; 35 Piano lesson 1
         begin_song_samples 53
         def_song_sample VIBRAPHONE
         def_song_sample KLAVES
@@ -633,6 +687,7 @@ SongSamples:
         def_song_sample ORGAN
         end_song_samples 53
 
+; 36 Piano lesson 2
         begin_song_samples 54
         def_song_sample VIBRAPHONE
         def_song_sample KLAVES
@@ -640,6 +695,7 @@ SongSamples:
         def_song_sample ORGAN
         end_song_samples 54
 
+; 37 Piano lesson 3
         begin_song_samples 55
         def_song_sample VIBRAPHONE
         def_song_sample KLAVES
@@ -647,6 +703,7 @@ SongSamples:
         def_song_sample ORGAN
         end_song_samples 55
 
+;38 Piano lesson 4
         begin_song_samples 56
         def_song_sample VIBRAPHONE
         def_song_sample KLAVES
@@ -655,26 +712,31 @@ SongSamples:
         def_song_sample ORGAN
         end_song_samples 56
 
+; 39 Piano lesson 5
         begin_song_samples 57
         def_song_sample VIBRAPHONE
         def_song_sample ORGAN
         end_song_samples 57
 
+; 3A Piano lesson 6
         begin_song_samples 58
         def_song_sample VIBRAPHONE
         def_song_sample ORGAN
         end_song_samples 58
 
+; 3B Piano lesson 7
         begin_song_samples 59
         def_song_sample VIBRAPHONE
         def_song_sample ORGAN
         end_song_samples 59
 
+; 3C Piano lesson 8
         begin_song_samples 60
         def_song_sample VIBRAPHONE
         def_song_sample ORGAN
         end_song_samples 60
 
+; 3D Musica Machina
         begin_song_samples 61
         def_song_sample TIMPANI
         def_song_sample BASS_GUITAR
@@ -684,9 +746,11 @@ SongSamples:
         def_song_sample FLUTE
         end_song_samples 61
 
+; 3E (a meteor is falling)
         begin_song_samples 62
         end_song_samples 62
 
+; 3F The Land Unknown
         begin_song_samples 63
         def_song_sample MANDOLIN
         def_song_sample HARP
@@ -700,6 +764,7 @@ SongSamples:
         def_song_sample KLAVES
         end_song_samples 63
 
+; 40 The Decisive Battle
         begin_song_samples 64
         def_song_sample STRINGS
         def_song_sample TRUMPET
@@ -713,6 +778,7 @@ SongSamples:
         def_song_sample DIST_GUITAR
         end_song_samples 64
 
+; 41 The Silent Beyond
         begin_song_samples 65
         def_song_sample FLUTE
         def_song_sample OBOE
@@ -721,11 +787,13 @@ SongSamples:
         def_song_sample STRINGS
         end_song_samples 65
 
+; 42 Dear Friends
         begin_song_samples 66
         def_song_sample MANDOLIN
         def_song_sample FLUTE
         end_song_samples 66
 
+; 43 Final Fantasy
         begin_song_samples 67
         def_song_sample HORN
         def_song_sample STRINGS
@@ -735,6 +803,7 @@ SongSamples:
         def_song_sample VIBRAPHONE
         end_song_samples 67
 
+; 44 A New Origin
         begin_song_samples 68
         def_song_sample STRINGS
         def_song_sample TRUMPET
@@ -746,12 +815,15 @@ SongSamples:
         def_song_sample HARP
         end_song_samples 68
 
+; 45 (crickets chirping)
         begin_song_samples 69
         end_song_samples 69
 
+; 46 a shore
         begin_song_samples 70
         end_song_samples 70
 
+; 47 the tide rolls in
         begin_song_samples 71
         end_song_samples 71
 

--- a/src/sound/sound-main.asm
+++ b/src/sound/sound-main.asm
@@ -51,7 +51,7 @@ _spc_block_seq .set 0
 
 .macro def_song_sample sample_id
         ; use the sample id plus 1 (zero means no sample)
-        .word sample_id
+        .word SAMPLE_BRR::sample_id + 1
 .endmac
 
 .macro begin_song_samples _song_id


### PR DESCRIPTION
Add enums for sample brrs as well as songs.

Might need to adjust how the code is generated in `sample_brr.inc` and `song_script.inc`.

----

I don't have to adjust after all, as according to `tools/romtools/insert_asm.py`, the generation is specified below a given indicator. Now to see whether it can generate customized enumeration.

----

I've cross-referred with ff6 and its doesn't look like it accounts for custom enumerations, either. I think this pr can be reviewed as it is; if customized enumeration is to be generated, it could be reserved for another pr.