### PR TITLE
Lower Case for File Getting

### DIFF
--- a/src/gfx/gfx-main.asm
+++ b/src/gfx/gfx-main.asm
@@ -177,7 +177,7 @@ WeaponHitTiles:
 ; d1/a3a0
 AttackPal:
         .repeat 128, i
-        .incbin .sprintf("attack_pal/pal_%04X.pal", i)
+        .incbin .sprintf("attack_pal/pal_%04x.pal", i)
         .endrep
 
 ; d1/aba0
@@ -223,7 +223,7 @@ BattleCharGfx:
         .if (i .mod 22) = 0
         .ident(.sprintf("BattleCharGfx_%d", i / 22)) := *
         .endif
-        .incbin .sprintf("battle_char_gfx/gfx_%04X.4bpp", i)
+        .incbin .sprintf("battle_char_gfx/gfx_%04x.4bpp", i)
         .endrep
 
 ; ------------------------------------------------------------------------------
@@ -238,7 +238,7 @@ BattleCharGfx:
 DeadCharGfx:
         .repeat 5, i
         .ident(.sprintf("DeadCharGfx_%d", i)) := *
-        .incbin .sprintf("dead_char_gfx/gfx_%04X.4bpp", i)
+        .incbin .sprintf("dead_char_gfx/gfx_%04x.4bpp", i)
         .endrep
 
 ; ------------------------------------------------------------------------------
@@ -268,7 +268,7 @@ BattleCharPal:
         .if (i .mod 22) = 0
         .ident(.sprintf("BattleCharPal_%d", i / 22)) := *
         .endif
-        .incbin .sprintf("battle_char_pal/pal_%04X.pal", i)
+        .incbin .sprintf("battle_char_pal/pal_%04x.pal", i)
         .endrep
 
 ; ------------------------------------------------------------------------------
@@ -684,7 +684,7 @@ BattleBGProp:
 ; d4/bb31: battle bg palettes (84 items, 32 bytes each)
 BattleBGPal:
         .repeat 84, i
-        .incbin .sprintf("battle_bg_pal/pal_%04X.pal", i)
+        .incbin .sprintf("battle_bg_pal/pal_%04x.pal", i)
         .endrep
 
 ; d4/c5b1: pointers to battle bg animation data (+$D40000)


### PR DESCRIPTION
When getting files in making a rom, the checks for files with hexadecimals are now in lower cases.

Closes #15.

I noticed in some lines of `sprintf(...)`, some of the "X"s in `%04X` are in upper case, while a few others are in lower. I think this determines whether the files will be searched in upper case instead of lower case so I made the correction accordingly.

Here's my output when I `make ff5-jp` after the changes:
```
ca65 -g -I include -D ROM_VERSION=0 -l obj/gfx-jp.lst src/gfx/gfx-main.asm -o obj/gfx-jp.o
ld65  -o "" -C cfg/ff5-jp.cfg obj/field-jp.o obj/btlgfx-jp.o obj/battle-jp.o obj/menu-jp.o obj/cutscene-jp.o obj/sound-jp.o obj/text-jp.o obj/gfx-jp.o
python3 tools/encode_cutscene.py temp_lz/cutscene.bin temp_lz/cutscene.lz
Cutscene CRC32: 0xAEF2C05E
Copying vanilla cutscene program
ca65 --bin-include-dir temp_lz temp_lz/cutscene_lz.asm -o temp_lz/cutscene.lz.o
ld65  --dbgfile rom/ff5-jp.dbg -m rom/ff5-jp.map -o rom/ff5-jp.sfc -C cfg/ff5-jp.cfg obj/field-jp.o obj/btlgfx-jp.o obj/battle-jp.o obj/menu-jp.o obj/cutscene-jp.o obj/sound-jp.o obj/text-jp.o obj/gfx-jp.o temp_lz/cutscene.lz.o
python3 tools/fix_checksum.py rom/ff5-jp.sfc
SNES Checksum: 0x696A
ROM CRC32: 0x97F08E21
```
I've found `rom/ff5-jp.sfc` in my project. Therefore, the rom making is successful. The rom also works fine in ZSNES, the snes emulator I'm now using for linux.